### PR TITLE
No need to delete win32 files in linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ ADDING TO PROJECTS
 			* In your release scheme, add libwebsocketswin32.lib, libeay32.lib, and ssleay32.lib
 			
 * Linux
-	* Delete the entire directory at ofxLibwebsockets/libs/libwebsockets/include/win32port
 	* 64-bit static version of libwebsockets is included; please let us know if you can contribute a 32 bit version!
 
 STATUS

--- a/example-client-hello world/Makefile
+++ b/example-client-hello world/Makefile
@@ -1,0 +1,13 @@
+# Attempt to load a config.make file.
+# If none is found, project defaults in config.project.make will be used.
+ifneq ($(wildcard config.make),)
+	include config.make
+endif
+
+# make sure the the OF_ROOT location is defined
+ifndef OF_ROOT
+    OF_ROOT=../../..
+endif
+
+# call the project makefile!
+include $(OF_ROOT)/libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk

--- a/example-server-binaryvideo/Makefile
+++ b/example-server-binaryvideo/Makefile
@@ -1,0 +1,13 @@
+# Attempt to load a config.make file.
+# If none is found, project defaults in config.project.make will be used.
+ifneq ($(wildcard config.make),)
+	include config.make
+endif
+
+# make sure the the OF_ROOT location is defined
+ifndef OF_ROOT
+    OF_ROOT=../../..
+endif
+
+# call the project makefile!
+include $(OF_ROOT)/libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk

--- a/example-server-echo/Makefile
+++ b/example-server-echo/Makefile
@@ -1,0 +1,13 @@
+# Attempt to load a config.make file.
+# If none is found, project defaults in config.project.make will be used.
+ifneq ($(wildcard config.make),)
+	include config.make
+endif
+
+# make sure the the OF_ROOT location is defined
+ifndef OF_ROOT
+    OF_ROOT=../../..
+endif
+
+# call the project makefile!
+include $(OF_ROOT)/libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk

--- a/example-server-sharedCanvas/Makefile
+++ b/example-server-sharedCanvas/Makefile
@@ -1,0 +1,13 @@
+# Attempt to load a config.make file.
+# If none is found, project defaults in config.project.make will be used.
+ifneq ($(wildcard config.make),)
+	include config.make
+endif
+
+# make sure the the OF_ROOT location is defined
+ifndef OF_ROOT
+    OF_ROOT=../../..
+endif
+
+# call the project makefile!
+include $(OF_ROOT)/libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk


### PR DESCRIPTION
Mention in the readme that there is no need to delete ofxLibwebsockets/libs/libwebsockets/include/win32port
And added some Makefiles for the examples.
