### PR TITLE
Fix for <iostream.h> not found, using cpp11 Xcode

### DIFF
--- a/libs/ofxLibwebsockets/include/ofxLibwebsockets/Connection.h
+++ b/libs/ofxLibwebsockets/include/ofxLibwebsockets/Connection.h
@@ -11,7 +11,7 @@
 //#include "ofMain.h"
 #include <libwebsockets.h>
 
-#include <iostream.h>
+#include <iostream>
 #include <vector>
 #include <string>
 
@@ -36,7 +36,7 @@ namespace ofxLibwebsockets {
         template <class T> 
         void sendBinary( T& image ){
             int size = image.width * image.height * image.getPixelsRef().getNumChannels();
-            cout<< size << endl;
+            std::cout<< size << std::endl;
             sendBinary( (unsigned char *) image.getPixels(), size );
         }
         


### PR DESCRIPTION
Hey,

I was trying out ofxLibwebsockets on [openFrameworks-cpp11/openFrameworks](https://github.com/openFrameworks-cpp11/openFrameworks). I am using xcode with cpp11. 

The only issue was that with this cpp11 repo has <iostream.h> in ofxLibwebsockets::Connections wasn't found. Fix provided below. 

I have tested this fix on of_v0.8.0_osx and all is ok. 
I have not testing on windows & linux but quite confident it should be ok.

Thanks,
Ross
