### PR TITLE
Reduce waitMillis to 0 to fix latency

### DIFF
--- a/libs/ofxLibwebsockets/src/Client.cpp
+++ b/libs/ofxLibwebsockets/src/Client.cpp
@@ -13,7 +13,7 @@ namespace ofxLibwebsockets {
     Client::Client(){
         context = NULL;
         connection = NULL;
-        waitMillis = 50;
+        waitMillis = 0;
         //count_pollfds = 0;
         reactors.push_back(this);
         

--- a/libs/ofxLibwebsockets/src/Server.cpp
+++ b/libs/ofxLibwebsockets/src/Server.cpp
@@ -16,7 +16,7 @@ namespace ofxLibwebsockets {
     //--------------------------------------------------------------
     Server::Server(){
         context = NULL;
-        waitMillis = 50;
+        waitMillis = 0;
         reactors.push_back(this);
         
         defaultOptions = defaultServerOptions();


### PR DESCRIPTION
I brought the waitMillis time from 50 down to 0, which helped to get rid of the lag seen on Windows. There's a remaining 50ms setting in `Reactor` but it seems like performance is ok with that in place?

I also left the locks in place – it seemed fine without them, but figured I'd leave them unless there's a reason to remove..
