### PR TITLE
Add reconnect to Client

### DIFF
--- a/libs/ofxLibwebsockets/include/ofxLibwebsockets/Client.h
+++ b/libs/ofxLibwebsockets/include/ofxLibwebsockets/Client.h
@@ -19,6 +19,8 @@ namespace ofxLibwebsockets {
         string  channel;
         string  protocol;
         int     version;
+        bool    reconnect;
+        int     reconnectInterval;
         
         // advanced: timeout options
         // names are from libwebsockets (ka == keep alive)
@@ -36,7 +38,7 @@ namespace ofxLibwebsockets {
         
         Client();
         ~Client();
-        
+
         // Note: the boolean returned here == libwebsockets setup success
         // You will receive an "onOpen" event on successful connect
         // and "onClose" on unsuccessful
@@ -81,7 +83,11 @@ namespace ofxLibwebsockets {
         Connection * getConnection(){
             return connection;
         }
-        
+
+        // Note: you do not need to call this function! It is called
+        // automatically and only used for reconnecting
+        void update(ofEventArgs& args);
+
     protected:
         ClientOptions defaultOptions;
         void onClose( Event& args );
@@ -95,6 +101,8 @@ namespace ofxLibwebsockets {
         
         //wrap protocol
         Protocol clientProtocol;
-        
+
+        bool bShouldReconnect;
+        uint64_t lastReconnectTime;
     };
 };

--- a/libs/ofxLibwebsockets/src/Client.cpp
+++ b/libs/ofxLibwebsockets/src/Client.cpp
@@ -12,12 +12,14 @@ namespace ofxLibwebsockets {
 
 	ClientOptions defaultClientOptions(){
        ClientOptions opts;
-       opts.host     = "localhost";
-       opts.port     = 80;
-       opts.bUseSSL  = false;
-       opts.channel  = "/";
-       opts.protocol = "NULL";
-       opts.version  = -1;     //use latest version
+       opts.host      = "localhost";
+       opts.port      = 80;
+       opts.bUseSSL   = false;
+       opts.channel   = "/";
+       opts.protocol  = "NULL";
+       opts.version   = -1;     //use latest version
+       opts.reconnect = true;
+       opts.reconnectInterval = 1000;
 
        opts.ka_time      = 0;
        opts.ka_probes    = 0;
@@ -33,7 +35,8 @@ namespace ofxLibwebsockets {
         reactors.push_back(this);
         
         defaultOptions = defaultClientOptions();
-        
+
+        ofAddListener( ofEvents().update, this, &Client::update);
         ofAddListener( clientProtocol.oncloseEvent, this, &Client::onClose);
     }
 
@@ -41,6 +44,7 @@ namespace ofxLibwebsockets {
     //--------------------------------------------------------------
     Client::~Client(){
         exit();
+        ofRemoveListener( ofEvents().update, this, &Client::update);
     }
     
     //--------------------------------------------------------------
@@ -67,7 +71,9 @@ namespace ofxLibwebsockets {
         address = options.host;
         port    = options.port;  
         channel = options.channel;
-        
+        defaultOptions = options;
+        bShouldReconnect = defaultOptions.reconnect;
+
 		/*
 			enum lws_log_levels {
 			LLL_ERR = 1 << 0,
@@ -172,6 +178,9 @@ namespace ofxLibwebsockets {
 
     //--------------------------------------------------------------
     void Client::close(){
+        // Self-initiated call to close() means we shouldn't try to reconnect
+        bShouldReconnect = false;
+
         if (isThreadRunning()){
             waitForThread(true);
         } else {
@@ -200,7 +209,9 @@ namespace ofxLibwebsockets {
 		if ( context != NULL ){
 			closeAndFree = true;
 			lwsconnection = NULL;
-		}     
+		}
+
+		lastReconnectTime = ofGetElapsedTimeMillis();
     }
 
     //--------------------------------------------------------------
@@ -230,7 +241,18 @@ namespace ofxLibwebsockets {
             connection->sendBinary(data,size);
         }
     }
-    
+
+    //--------------------------------------------------------------
+    void Client::update(ofEventArgs& args) {
+        if (!isConnected() && bShouldReconnect) {
+            uint64_t now = ofGetElapsedTimeMillis();
+            if (now - lastReconnectTime > defaultOptions.reconnectInterval) {
+                lastReconnectTime = now;
+                connect( defaultOptions );
+            }
+        }
+    }
+
     //--------------------------------------------------------------
     void Client::threadedFunction(){
         while ( isThreadRunning() ){


### PR DESCRIPTION
Got tired of implementing reconnects in my apps and figured the addon might as well support it. I added some new options to `ClientOptions` so you can enable/disable the reconnect option and the timing (defaults to on, 1s).

 This seems to work fine with a reconnect time of 1s, but I get some weird crashes ~half the time when I lower it.  Maybe you've got a better idea of what's going on here?

![lws](https://cloud.githubusercontent.com/assets/2334552/13398149/08a9e2e8-decb-11e5-90db-df88da004a23.png)
Not sure why this is failing...the debugger shows `context` has a memory address/is not NULL, and the code only gets here after `startThread()` is called sooo.... `¯\_(ツ)_/¯ `